### PR TITLE
Fix: Use singlequotes instead of backticks.

### DIFF
--- a/hash_comparison_validation_of_gem.rb
+++ b/hash_comparison_validation_of_gem.rb
@@ -80,7 +80,7 @@ module Verify
       if `which wget` && $? == 0 then
         'wget'
       elsif `which curl` && $? == 0 then
-        `curl -O`
+        'curl -O'
       else
         raise 'Unable to find curl or wget, install one of them and get back to me.'
       end


### PR DESCRIPTION
Mistakenly used backticks which will always return an empty string,
leaving people without wget probably quite confused.
